### PR TITLE
GA tests + port over classes removed from connector-common

### DIFF
--- a/.github/contrib/settings.xml
+++ b/.github/contrib/settings.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+      <server>
+      <username>mb-gatesprojects</username>
+      <password>ModusBox</password>
+      <id>modusbox-release-local</id>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>http://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <snapshots><enabled>false</enabled></snapshots>
+          <id>modusbox-release-local</id>
+          <name>libs-release</name>
+          <url>https://modusbox.jfrog.io/modusbox/libs-release</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>http://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <snapshots><enabled>false</enabled></snapshots>
+          <releases><updatePolicy>never</updatePolicy></releases>
+        </pluginRepository>
+        <pluginRepository>
+          <snapshots><enabled>false</enabled></snapshots>
+          <id>modusbox-plugin-release</id>
+          <name>plugins-release</name>
+          <url>https://modusbox.jfrog.io/modusbox/plugins-release</url>
+        </pluginRepository>
+      </pluginRepositories>
+      <id>artifactory</id>
+    </profile>
+  </profiles>
+</settings>
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,26 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
   Assemble:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+
+      - name: Check out ph-ee-connector-common repository code
+        uses: actions/checkout@master
+        with:
+          repository: openMF/ph-ee-connector-common
+          ref: 'ac68e99aed3cc48542c207212c528f005bf02531'
+          path: 'ph-ee-connector-common'
+
+      - name: Copy settings.xml
+        run: mkdir $HOME/.m2 ; cp -v .github/contrib/settings.xml $HOME/.m2/
+
+      - name: Install ph-ee-connector-common
+        working-directory: ph-ee-connector-common
+#        run: ./gradlew clean install
+        run: mvn clean install
+
       - name: Package project
-        run: mvn -U clean package
+        run: mvn -U clean test package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+name: Test
+on: [push]
+jobs:
+  Assemble:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Package project
+        run: mvn -U clean package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Package project
         run: mvn -U clean test package
+
+      - name: Build Docker image
+        run: docker build . -t paymenthubee.mifos.io/phee/connector-mojaloop-java

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,16 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: openMF/ph-ee-connector-common
-          ref: 'ac68e99aed3cc48542c207212c528f005bf02531'
+          ref: 'refs/heads/master'
           path: 'ph-ee-connector-common'
-
-      - name: Copy settings.xml
-        run: mkdir $HOME/.m2 ; cp -v .github/contrib/settings.xml $HOME/.m2/
 
       - name: Install ph-ee-connector-common
         working-directory: ph-ee-connector-common
-#        run: ./gradlew clean install
-        run: mvn clean install
+        run: ./gradlew clean install
+#        run: mvn clean install
+
+      - name: Copy settings.xml
+        run: cp -v .github/contrib/settings.xml $HOME/.m2/
 
       - name: Package project
         run: mvn -U clean test package

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,20 @@
 	<artifactId>ph-ee-connector-mojaloop-java</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>modusbox-release-local</id>
+			<name>libs-release</name>
+			<url>https://modusbox.jfrog.io/modusbox/libs-release</url>
+		</repository>
+	</repositories>
+
 	<properties>
 		<camel.version>3.4.0</camel.version>
+		<ilp.version>1.3</ilp.version>
 		<compiler-plugin.version>3.8.1</compiler-plugin.version>
 
 		<maven.compiler.parameters>true</maven.compiler.parameters>
@@ -46,9 +58,9 @@
 			<version>${camel.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.zeebe</groupId>
-			<artifactId>zeebe-client-java</artifactId>
-			<version>0.26.0</version>
+			<groupId>com.interop.ilp.conditions</groupId>
+			<artifactId>interop-ilp-conditions</artifactId>
+			<version>${ilp.version}</version>
 		</dependency>
 
 		<!-- test deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<camel.version>3.4.0</camel.version>
 		<ilp.version>1.3</ilp.version>
+		<zeebe.version>1.1.0</zeebe.version>
 		<compiler-plugin.version>3.8.1</compiler-plugin.version>
 
 		<maven.compiler.parameters>true</maven.compiler.parameters>
@@ -56,6 +57,11 @@
 			<groupId>org.apache.camel.springboot</groupId>
 			<artifactId>camel-jackson-starter</artifactId>
 			<version>${camel.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.camunda</groupId>
+			<artifactId>zeebe-client-java</artifactId>
+			<version>${zeebe.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.interop.ilp.conditions</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,16 @@
 			<artifactId>interop-ilp-conditions</artifactId>
 			<version>${ilp.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20190722</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.10.1</version>
+		</dependency>
 
 		<!-- test deps -->
 		<dependency>

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/CodecContextFactory.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/CodecContextFactory.java
@@ -7,22 +7,6 @@
  */
 
 package org.mifos.connector.mojaloop.ilp;
-//
-//import org.interledger.Condition;
-//import org.interledger.InterledgerAddress;
-//import org.interledger.codecs.CodecContext;
-//import org.interledger.codecs.oer.*;
-//import org.interledger.codecs.oer.ilp.ConditionOerCodec;
-//import org.interledger.codecs.oer.ilp.InterledgerAddressOerCodec;
-//import org.interledger.codecs.oer.ilp.InterledgerPacketTypeOerCodec;
-//import org.interledger.codecs.oer.ilp.InterledgerPaymentOerCodec;
-//import org.interledger.codecs.oer.ilqp.*;
-//import org.interledger.codecs.oer.ipr.InterledgerPaymentRequestOerCodec;
-//import org.interledger.codecs.packettypes.InterledgerPacketType;
-//import org.interledger.codecs.psk.PskMessageBinaryCodec;
-//import org.interledger.ilqp.*;
-//import org.interledger.ipr.InterledgerPaymentRequest;
-//import org.interledger.psk.PskMessage;
 
 import org.interledger.Condition;
 import org.interledger.InterledgerAddress;

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/CodecContextFactory.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/CodecContextFactory.java
@@ -1,0 +1,76 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at
+ *
+ *  https://mozilla.org/MPL/2.0/.
+ */
+
+package org.mifos.connector.mojaloop.ilp;
+//
+//import org.interledger.Condition;
+//import org.interledger.InterledgerAddress;
+//import org.interledger.codecs.CodecContext;
+//import org.interledger.codecs.oer.*;
+//import org.interledger.codecs.oer.ilp.ConditionOerCodec;
+//import org.interledger.codecs.oer.ilp.InterledgerAddressOerCodec;
+//import org.interledger.codecs.oer.ilp.InterledgerPacketTypeOerCodec;
+//import org.interledger.codecs.oer.ilp.InterledgerPaymentOerCodec;
+//import org.interledger.codecs.oer.ilqp.*;
+//import org.interledger.codecs.oer.ipr.InterledgerPaymentRequestOerCodec;
+//import org.interledger.codecs.packettypes.InterledgerPacketType;
+//import org.interledger.codecs.psk.PskMessageBinaryCodec;
+//import org.interledger.ilqp.*;
+//import org.interledger.ipr.InterledgerPaymentRequest;
+//import org.interledger.psk.PskMessage;
+
+import org.interledger.Condition;
+import org.interledger.InterledgerAddress;
+import org.interledger.codecs.CodecContext;
+import org.interledger.codecs.oer.*;
+import org.interledger.codecs.oer.ilp.ConditionOerCodec;
+import org.interledger.codecs.oer.ilp.InterledgerAddressOerCodec;
+import org.interledger.codecs.oer.ilp.InterledgerPacketTypeOerCodec;
+import org.interledger.codecs.oer.ilqp.*;
+import org.interledger.codecs.oer.ipr.InterledgerPaymentRequestOerCodec;
+import org.interledger.codecs.packettypes.InterledgerPacketType;
+import org.interledger.codecs.psk.PskMessageBinaryCodec;
+import org.interledger.ilqp.*;
+import org.interledger.ipr.InterledgerPaymentRequest;
+import org.interledger.psk.PskMessage;
+
+public class CodecContextFactory {
+
+    public static CodecContext interledger() {
+        return (new CodecContext())
+                .register(OerUint8Codec.OerUint8.class, new OerUint8Codec())
+                .register(OerUint32Codec.OerUint32.class, new OerUint32Codec())
+                .register(OerUint64Codec.OerUint64.class, new OerUint64Codec())
+                .register(OerUint256Codec.OerUint256.class, new OerUint256Codec())
+                .register(OerLengthPrefixCodec.OerLengthPrefix.class, new OerLengthPrefixCodec())
+                .register(OerIA5StringCodec.OerIA5String.class, new OerIA5StringCodec())
+                .register(OerOctetStringCodec.OerOctetString.class, new OerOctetStringCodec())
+                .register(OerGeneralizedTimeCodec.OerGeneralizedTime.class, new OerGeneralizedTimeCodec())
+                .register(InterledgerAddress.class, new InterledgerAddressOerCodec())
+                .register(InterledgerPacketType.class, new InterledgerPacketTypeOerCodec())
+                .register(org.interledger.ilp.InterledgerPayment.class, new org.interledger.codecs.oer.ilp.InterledgerPaymentOerCodec())
+                .register(InterledgerPaymentRequest.class, new InterledgerPaymentRequestOerCodec())
+                .register(Condition.class, new ConditionOerCodec())
+                .register(QuoteByDestinationAmountRequest.class, new QuoteByDestinationAmountRequestOerCodec())
+                .register(QuoteByDestinationAmountResponse.class, new QuoteByDestinationAmountResponseOerCodec())
+                .register(QuoteBySourceAmountRequest.class, new QuoteBySourceAmountRequestOerCodec())
+                .register(QuoteBySourceAmountResponse.class, new QuoteBySourceAmountResponseOerCodec())
+                .register(QuoteLiquidityRequest.class, new QuoteLiquidityRequestOerCodec())
+                .register(QuoteLiquidityResponse.class, new QuoteLiquidityResponseOerCodec())
+                .register(PskMessage.class, new PskMessageBinaryCodec())
+                .register(InterledgerPayment.class, new InterledgerPaymentOerCodec());
+    }
+
+    public static CodecContext interledgerJson() {
+        throw new RuntimeException("Not yet implemented!");
+    }
+
+    public static CodecContext interledgerProtobuf() {
+        throw new RuntimeException("Not yet implemented!");
+    }
+}

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/Ilp.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/Ilp.java
@@ -1,0 +1,68 @@
+package org.mifos.connector.mojaloop.ilp;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at
+ *
+ *  https://mozilla.org/MPL/2.0/.
+ */
+
+
+import com.ilp.conditions.models.pdp.Transaction;
+
+public class Ilp {
+
+    private final String packet; // mandatory
+    private final String condition; // mandatory
+    private final String fulfilment; // optional
+    private final Transaction transaction; // mandatory
+
+    public Ilp(String packet, String condition, String fulfilment, Transaction transaction) {
+        this.packet = packet;
+        this.condition = condition;
+        this.fulfilment = fulfilment;
+        this.transaction = transaction;
+    }
+
+    public Ilp(String packet, String condition, Transaction transaction) {
+        this(packet, condition, null, transaction);
+    }
+
+    public String getPacket() {
+        return packet;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public String getFulfilment() {
+        return fulfilment;
+    }
+
+    public Transaction getTransaction() {
+        return transaction;
+    }
+
+    void update(Ilp oIlp) {
+        if (oIlp == null)
+            return;
+        if (!packet.equals(oIlp.getPacket()))
+            throw new RuntimeException("Ilp packet is not valid " + packet + " vs." + oIlp.getPacket());
+        if (!condition.equals(oIlp.getCondition()))
+            throw new RuntimeException("Ilp condition is not valid " + packet + " vs." + oIlp.getPacket());
+        if (fulfilment != null && oIlp.getFulfilment() != null && !fulfilment.equals(oIlp.getFulfilment()))
+            throw new RuntimeException("Ilp fulfilment is not valid " + fulfilment + " vs." + oIlp.getFulfilment());
+
+    }
+
+    @Override
+    public String toString() {
+        return "Ilp{" +
+                "packet:'" + packet + '\'' +
+                ", condition:'" + condition + '\'' +
+                ", fulfilment:'" + fulfilment + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/IlpConditionHandlerImpl.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/IlpConditionHandlerImpl.java
@@ -14,8 +14,6 @@ import org.interledger.Condition;
 import org.interledger.Fulfillment;
 import org.interledger.InterledgerAddress;
 import org.interledger.codecs.CodecContext;
-import org.mifos.connector.common.mojaloop.ilp.CodecContextFactory;
-import org.mifos.connector.common.mojaloop.ilp.InterledgerPayment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPayment.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPayment.java
@@ -1,0 +1,102 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at
+ *
+ *  https://mozilla.org/MPL/2.0/.
+ */
+package org.mifos.connector.mojaloop.ilp;
+
+import org.interledger.InterledgerAddress;
+import org.interledger.InterledgerPacket;
+import java.util.Arrays;
+import java.util.Objects;
+
+public interface InterledgerPayment
+	extends InterledgerPacket
+{
+    static InterledgerPayment.Builder builder() {
+        return new InterledgerPayment.Builder();
+    }
+
+    InterledgerAddress getDestinationAccount();
+
+    String getDestinationAmount();
+
+    byte[] getData();
+
+    public static class Builder {
+                private InterledgerAddress destinationAccount;
+        private String destinationAmount;
+        private byte[] data;
+
+        public Builder() {
+        }
+
+        public InterledgerPayment.Builder destinationAccount(InterledgerAddress destinationAccount) {
+            this.destinationAccount = (InterledgerAddress)Objects.requireNonNull(destinationAccount);
+            return this;
+        }
+
+        public InterledgerPayment.Builder destinationAmount(String destinationAmount) {
+            this.destinationAmount = (String)Objects.requireNonNull(destinationAmount);
+            return this;
+        }
+
+        public InterledgerPayment.Builder data(byte[] data) {
+            this.data = (byte[])Objects.requireNonNull(data);
+            return this;
+        }
+
+        public InterledgerPayment build() {
+            return new InterledgerPayment.Builder.Impl(this);
+        }
+
+        private static final class Impl implements InterledgerPayment {
+                        private final InterledgerAddress destinationAccount;
+            private final String destinationAmount;
+            private final byte[] data;
+
+            private Impl(InterledgerPayment.Builder builder) {
+                Objects.requireNonNull(builder);
+                this.destinationAccount = (InterledgerAddress)Objects.requireNonNull(builder.destinationAccount, "destinationAccount must not be null!");
+                this.destinationAmount = (String)Objects.requireNonNull(builder.destinationAmount, "destinationAmount must not be null!");
+                this.data = (byte[])Objects.requireNonNull(builder.data, "data must not be null!");
+            }
+
+            public InterledgerAddress getDestinationAccount() {
+                return this.destinationAccount;
+            }
+
+            public String getDestinationAmount() {
+                return this.destinationAmount;
+            }
+
+            public byte[] getData() {
+                return Arrays.copyOf(this.data, this.data.length);
+            }
+
+            public boolean equals(Object obj) {
+                if (this == obj) {
+                    return true;
+                } else if (obj != null && this.getClass() == obj.getClass()) {
+                    InterledgerPayment.Builder.Impl impl = (InterledgerPayment.Builder.Impl)obj;
+                    return this.destinationAccount.equals(impl.destinationAccount) && this.destinationAmount.equals(impl.destinationAmount) && Arrays.equals(this.data, impl.data);
+                } else {
+                    return false;
+                }
+            }
+
+            public int hashCode() {
+                int result = this.destinationAccount.hashCode();
+                result = 31 * result + this.destinationAmount.hashCode();
+                result = 31 * result + Arrays.hashCode(this.data);
+                return result;
+            }
+
+            public String toString() {
+                return "InterledgerPayment.Impl{destinationAccount=" + this.destinationAccount + ", destinationAmount=" + this.destinationAmount + ", data=" + Arrays.toString(this.data) + '}';
+            }
+        }
+    }
+}

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPaymentCodec.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPaymentCodec.java
@@ -1,0 +1,20 @@
+package org.mifos.connector.mojaloop.ilp;
+/*
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at
+ *
+ *  https://mozilla.org/MPL/2.0/.
+ */
+
+import org.interledger.codecs.InterledgerPacketCodec;
+import org.interledger.codecs.packettypes.InterledgerPacketType;
+import org.interledger.codecs.packettypes.PaymentPacketType;
+
+public interface InterledgerPaymentCodec extends InterledgerPacketCodec<InterledgerPayment> {
+    InterledgerPacketType TYPE = new PaymentPacketType();
+
+    default InterledgerPacketType getTypeId() {
+        return TYPE;
+    }
+}

--- a/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPaymentOerCodec.java
+++ b/src/main/java/org/mifos/connector/mojaloop/ilp/InterledgerPaymentOerCodec.java
@@ -1,0 +1,37 @@
+package org.mifos.connector.mojaloop.ilp;
+
+
+import org.interledger.InterledgerAddress;
+import org.interledger.codecs.CodecContext;
+import org.interledger.codecs.oer.OerIA5StringCodec;
+import org.interledger.codecs.oer.OerOctetStringCodec;
+import org.interledger.codecs.packettypes.InterledgerPacketType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
+
+public class InterledgerPaymentOerCodec implements InterledgerPaymentCodec {
+    public InterledgerPaymentOerCodec() {
+    }
+
+    public InterledgerPayment read(CodecContext context, InputStream inputStream) throws IOException {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(inputStream);
+        String destinationAmount = context.read(OerIA5StringCodec.OerIA5String.class, inputStream).getValue();
+        InterledgerAddress destinationAccount = context.read(InterledgerAddress.class, inputStream);
+        byte[] data = context.read(OerOctetStringCodec.OerOctetString.class, inputStream).getValue();
+        return InterledgerPayment.builder().destinationAmount(destinationAmount).destinationAccount(destinationAccount).data(data).build();
+    }
+
+    public void write(CodecContext context, InterledgerPayment instance, OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(instance);
+        Objects.requireNonNull(outputStream);
+        context.write(InterledgerPacketType.class, this.getTypeId(), outputStream);
+        context.write(OerIA5StringCodec.OerIA5String.class, new OerIA5StringCodec.OerIA5String(instance.getDestinationAmount()), outputStream);
+        context.write(InterledgerAddress.class, instance.getDestinationAccount(), outputStream);
+        context.write(OerOctetStringCodec.OerOctetString.class, new OerOctetStringCodec.OerOctetString(instance.getData()), outputStream);
+    }
+}

--- a/src/main/java/org/mifos/connector/mojaloop/party/PartiesResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/mojaloop/party/PartiesResponseProcessor.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.party;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.mifos.connector.common.mojaloop.dto.PartySwitchResponseDTO;

--- a/src/main/java/org/mifos/connector/mojaloop/party/PartyLookupWorkers.java
+++ b/src/main/java/org/mifos/connector/mojaloop/party/PartyLookupWorkers.java
@@ -1,7 +1,7 @@
 package org.mifos.connector.mojaloop.party;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;

--- a/src/main/java/org/mifos/connector/mojaloop/quote/QuoteResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/mojaloop/quote/QuoteResponseProcessor.java
@@ -2,7 +2,7 @@ package org.mifos.connector.mojaloop.quote;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.mifos.connector.common.mojaloop.dto.QuoteSwitchResponseDTO;

--- a/src/main/java/org/mifos/connector/mojaloop/quote/QuoteRoutes.java
+++ b/src/main/java/org/mifos/connector/mojaloop/quote/QuoteRoutes.java
@@ -17,7 +17,7 @@ import org.mifos.connector.common.mojaloop.dto.PartyIdInfo;
 import org.mifos.connector.common.mojaloop.dto.QuoteSwitchRequestDTO;
 import org.mifos.connector.common.mojaloop.dto.QuoteSwitchResponseDTO;
 import org.mifos.connector.common.mojaloop.dto.TransactionType;
-import org.mifos.connector.common.mojaloop.ilp.Ilp;
+import org.mifos.connector.mojaloop.ilp.Ilp;
 import org.mifos.connector.common.mojaloop.type.AmountType;
 import org.mifos.connector.mojaloop.camel.trace.AddTraceHeaderProcessor;
 import org.mifos.connector.mojaloop.ilp.IlpBuilder;

--- a/src/main/java/org/mifos/connector/mojaloop/quote/QuoteWorkers.java
+++ b/src/main/java/org/mifos/connector/mojaloop/quote/QuoteWorkers.java
@@ -1,7 +1,7 @@
 package org.mifos.connector.mojaloop.quote;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;

--- a/src/main/java/org/mifos/connector/mojaloop/transactionrequest/TransactionResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transactionrequest/TransactionResponseProcessor.java
@@ -1,7 +1,7 @@
 package org.mifos.connector.mojaloop.transactionrequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.mifos.connector.common.mojaloop.dto.TransactionRequestSwitchResponseDTO;

--- a/src/main/java/org/mifos/connector/mojaloop/transactionrequest/TransactionWorkers.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transactionrequest/TransactionWorkers.java
@@ -1,7 +1,7 @@
 package org.mifos.connector.mojaloop.transactionrequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;

--- a/src/main/java/org/mifos/connector/mojaloop/transfer/TransferResponseProcessor.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transfer/TransferResponseProcessor.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.transfer;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.mifos.connector.common.mojaloop.dto.TransferSwitchResponseDTO;

--- a/src/main/java/org/mifos/connector/mojaloop/transfer/TransferRoutes.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transfer/TransferRoutes.java
@@ -13,7 +13,7 @@ import org.mifos.connector.common.mojaloop.dto.MoneyData;
 import org.mifos.connector.common.mojaloop.dto.QuoteSwitchResponseDTO;
 import org.mifos.connector.common.mojaloop.dto.TransferSwitchRequestDTO;
 import org.mifos.connector.common.mojaloop.dto.TransferSwitchResponseDTO;
-import org.mifos.connector.common.mojaloop.ilp.Ilp;
+import org.mifos.connector.mojaloop.ilp.Ilp;
 import org.mifos.connector.common.mojaloop.type.TransferState;
 import org.mifos.connector.common.util.ContextUtil;
 import org.mifos.connector.mojaloop.camel.trace.AddTraceHeaderProcessor;

--- a/src/main/java/org/mifos/connector/mojaloop/transfer/TransferRoutes.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transfer/TransferRoutes.java
@@ -2,7 +2,7 @@ package org.mifos.connector.mojaloop.transfer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ilp.conditions.models.pdp.Transaction;
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;

--- a/src/main/java/org/mifos/connector/mojaloop/transfer/TransferWorkers.java
+++ b/src/main/java/org/mifos/connector/mojaloop/transfer/TransferWorkers.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.transfer;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;

--- a/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeClientConfiguration.java
+++ b/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeClientConfiguration.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.zeebe;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeProcessStarter.java
+++ b/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeProcessStarter.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.zeebe;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.apache.camel.Exchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeeWorkers.java
+++ b/src/main/java/org/mifos/connector/mojaloop/zeebe/ZeebeeWorkers.java
@@ -1,6 +1,6 @@
 package org.mifos.connector.mojaloop.zeebe;
 
-import io.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClient;
 import org.mifos.connector.common.mojaloop.type.TransactionRequestState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
 
     <logger name="org" level="INFO"/>
     <logger name="io" level="INFO"/>
-<!--    <logger name="io.zeebe.client.job.poller" level="TRACE"/>-->
+<!--    <logger name="io.camunda.zeebe.client.job.poller" level="TRACE"/>-->
 <!--    <logger name="hu.dpc" level="TRACE"/>-->
 <!--    <logger name="org.eclipse" level="TRACE"/>-->
 


### PR DESCRIPTION
Based on the other tests branch, but also ports over dependencies from connector-common which concretely depend on ILP. connector-common is removing support for this as it's proprietary. 

Also, start building docker image in tests