### PR TITLE
Upgrade Zeebe to 8.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 ext {
     camelVersion = '3.18.1'
-    zeebClientVersion = '1.3.1'
+    zeebClientVersion = '8.1.1'
 }
 
 configurations.all {


### PR DESCRIPTION
This PR upgrades the zeebe client version to 8.1.1

JIRA: [GOV-449](https://mifosforge.jira.com/browse/GOV-449)


[GOV-449]: https://mifosforge.jira.com/browse/GOV-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ